### PR TITLE
Abstract logic for looking up Service instance

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,7 +73,7 @@ func main() {
 		log.Fatal().Err(err).Msg("Unable to create tls cert handler")
 	}
 
-	svc := est.NewService(rootCert, caCert, caKey)
+	svcHandler := est.NewStaticServiceHandler(est.NewService(rootCert, caCert, caKey))
 
 	e := echo.New()
 	s := http.Server{
@@ -88,7 +88,7 @@ func main() {
 	if err = est.ApplyTlsCertHandler(s.TLSConfig, tlsHandler); err != nil {
 		log.Fatal().Err(err).Msg("Unable to configure TLS handler")
 	}
-	est.RegisterEchoHandlers(svc, e)
+	est.RegisterEchoHandlers(svcHandler, e)
 
 	if err = est.RunGracefully(ctx, &s, e); err != nil {
 		log.Fatal().Err(err).Msg("Unable to run server")

--- a/http_test.go
+++ b/http_test.go
@@ -52,7 +52,7 @@ func (tc testClient) POST(t *testing.T, resource string, data []byte, cert *tls.
 func WithEstServer(t *testing.T, testFunc func(tc testClient)) {
 	svc := createService(t)
 	e := echo.New()
-	RegisterEchoHandlers(svc, e)
+	RegisterEchoHandlers(NewStaticServiceHandler(svc), e)
 
 	ctx := CtxWithLog(context.TODO(), InitLogger(""))
 	srv := httptest.NewUnstartedServer(e)

--- a/service.go
+++ b/service.go
@@ -62,6 +62,22 @@ var (
 	asn1TlsWebClientAuth = []byte{48, 10, 6, 8, 43, 6, 1, 5, 5, 7, 3, 2}
 )
 
+type ServiceHandler interface {
+	GetService(ctx context.Context, serverName string) (Service, error)
+}
+
+type staticSvcHandler struct {
+	Service
+}
+
+func (s staticSvcHandler) GetService(ctx context.Context, serverName string) (Service, error) {
+	return s.Service, nil
+}
+
+func NewStaticServiceHandler(svc Service) ServiceHandler {
+	return &staticSvcHandler{svc}
+}
+
 // Service represents a thin API to handle required operations of EST7030.
 // This service implements the required parts of EST. Specifically:
 //


### PR DESCRIPTION
When we run in a multi-tenant mode, the http handlers must be able to dynamically look up which est service instance to use based on the server name.

Signed-off-by: Andy Doan <andy@foundries.io>