### PR TITLE
Feature: support multiple root CA certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bin/
+*.swp
+*.swo

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
+linter:=$(shell which golangci-lint 2>/dev/null || echo $(HOME)/go/bin/golangci-lint)
+
 format:
 	@gofmt -l  -w ./
 
-check: test
+check: test lint
+
+lint:
 	@test -z $(shell gofmt -l ./ | tee /dev/stderr) || (echo "[WARN] Fix formatting issues with 'make format'"; exit 1)
-	@test -x $(linter) || (echo "Please install linter from https://github.com/golangci/golangci-lint/releases/tag/v1.25.1 to $(HOME)/go/bin")
+	@test -x $(linter) || (echo "Please install linter from https://github.com/golangci/golangci-lint/releases/tag/v1.49.0 to $(HOME)/go/bin")
 	$(linter) run
 
 test:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -133,6 +133,9 @@ func loadPem(log zerolog.Logger, fileName string) *pem.Block {
 		log.Fatal().Err(err).Msg("Can't read file")
 	}
 	block, extra := pem.Decode(buf)
+	if block == nil {
+		log.Fatal().Str("file", fileName).Bytes("extra", buf).Msg("Can't parse")
+	}
 	extra = bytes.TrimSpace(extra)
 	if len(extra) > 0 {
 		log.Fatal().Str("file", fileName).Bytes("extra", extra).Msg("Can't parse")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -65,7 +65,6 @@ func main() {
 	caKey := loadKey(log, required[2].value)
 
 	caPool := x509.NewCertPool()
-	caPool.AddCert(rootCert)
 	caPool.AddCert(caCert)
 
 	if clientCas != nil && len(*clientCas) > 0 {

--- a/http_test.go
+++ b/http_test.go
@@ -58,7 +58,9 @@ func WithEstServer(t *testing.T, testFunc func(tc testClient)) {
 	srv := httptest.NewUnstartedServer(e)
 
 	pool := x509.NewCertPool()
-	pool.AddCert(svc.rootCa)
+	for _, cert := range svc.rootCa {
+		pool.AddCert(cert)
+	}
 	srv.TLS = &tls.Config{
 		ClientAuth: tls.VerifyClientCertIfGiven,
 		ClientCAs:  pool,

--- a/service_test.go
+++ b/service_test.go
@@ -71,7 +71,7 @@ func createService(t *testing.T) Service {
 	cert, err := x509.ParseCertificate(der)
 	require.Nil(t, err)
 
-	return Service{cert, cert, key, time.Hour * 24}
+	return Service{[]*x509.Certificate{cert}, cert, key, time.Hour * 24}
 }
 
 func TestService_CA(t *testing.T) {


### PR DESCRIPTION
This is needed to support the root CA renewal feature.

During the initial phase of that renewal, a server needs to send clients:
- A new root CA,
- A cross-signed copy of that new CA, so that clients can validate the chain of trust using a previous root CA,
- And a previous root CA, so that clients can still trust the existing server TLS certificates during interregnum.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>